### PR TITLE
install check source specified by plugin_name to plugin_dir

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: docker
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-12.04
+    driver_config:
+      provision_command:
+        - apt-get update
+
+suites:
+  - name: default
+    run_list:
+      - recipe[nrpe::default]
+      - recipe[nrpe::_lwrp_test]
+    attributes:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Parameters:
 - *plugin_dir (optional)*          - nrpe plugin lib directory
 - *plugin_name (required)*           - nrpe plugin name
 - *plugin_args (required)*          - nrpe plugin check command arguments
-
+- *skip_check_installation*         - whether or not to install check sourcecode "plugin_name" to plugin_dir (default: false)
 
 
 ## Cookbook Core Attributes

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Parameters:
 - *plugin_dir (optional)*          - nrpe plugin lib directory
 - *plugin_name (required)*           - nrpe plugin name
 - *plugin_args (required)*          - nrpe plugin check command arguments
-- *skip_check_installation*         - whether or not to install check sourcecode "plugin_name" to plugin_dir (default: false)
+- *install_check*         - whether or not to install check sourcecode "plugin_name" to plugin_dir (default: false)
 
 
 ## Cookbook Core Attributes

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -25,6 +25,13 @@ action :create do
   Chef::Log.warn("#{new_resource.plugin_dir} plugin dir does not exists") unless ::File.exist?(new_resource.plugin_dir)
   Chef::Log.warn("#{new_resource.plugin_name} plugin file does not exists") unless ::File.exist?(::File.join(new_resource.plugin_dir, new_resource.plugin_name))
 
+  cookbook_file "install check #{new_resource.plugin_name} on #{node['fqdn']}" do
+    path ::File.join(new_resource.plugin_dir, new_resource.plugin_name)
+    source new_resource.plugin_name
+    mode 0755
+    only_if { !new_resource.skip_check_installation }
+  end
+
   t = template ::File.join(node['nrpe']['include_dir'], new_resource.command_name + '.cfg') do
     owner node['nrpe']['user']
     group node['nrpe']['group']

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -30,7 +30,7 @@ action :create do
     cookbook "nrpe"
     source new_resource.plugin_name
     mode 0755
-    only_if { !new_resource.skip_check_installation }
+    only_if { new_resource.install_check }
   end
 
   t = template ::File.join(node['nrpe']['include_dir'], new_resource.command_name + '.cfg') do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -27,6 +27,7 @@ action :create do
 
   cookbook_file "install check #{new_resource.plugin_name} on #{node['fqdn']}" do
     path ::File.join(new_resource.plugin_dir, new_resource.plugin_name)
+    cookbook "nrpe"
     source new_resource.plugin_name
     mode 0755
     only_if { !new_resource.skip_check_installation }

--- a/recipes/_lwrp_test.rb
+++ b/recipes/_lwrp_test.rb
@@ -1,0 +1,12 @@
+nrpe "check_iowait" do
+  plugin_dir "/usr/lib/nagios/plugins"
+  plugin_name "check_iowait.sh"
+  plugin_args "10 20"
+end
+
+nrpe "check_load" do
+  plugin_dir "/usr/lib/nagios/plugins"
+  plugin_name "check_test"
+  plugin_args "10 20"
+  skip_check_installation true
+end

--- a/recipes/_lwrp_test.rb
+++ b/recipes/_lwrp_test.rb
@@ -2,11 +2,11 @@ nrpe "check_iowait" do
   plugin_dir "/usr/lib/nagios/plugins"
   plugin_name "check_iowait.sh"
   plugin_args "10 20"
+  install_check true
 end
 
 nrpe "check_load" do
   plugin_dir "/usr/lib/nagios/plugins"
   plugin_name "check_test"
   plugin_args "10 20"
-  skip_check_installation true
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -25,3 +25,4 @@ attribute :command_name,  :name_attribute => true, :kind_of => String, :default 
 attribute :plugin_name,   :required => true, :kind_of => String, :default => nil
 attribute :plugin_args,   :required => true, :kind_of => String, :default => nil
 attribute :plugin_dir,    :kind_of => String, :default => node['nrpe']['plugins_dir']
+attribute :skip_check_installation,    :kind_of => [ TrueClass, FalseClass ], :default => false

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -25,4 +25,4 @@ attribute :command_name,  :name_attribute => true, :kind_of => String, :default 
 attribute :plugin_name,   :required => true, :kind_of => String, :default => nil
 attribute :plugin_args,   :required => true, :kind_of => String, :default => nil
 attribute :plugin_dir,    :kind_of => String, :default => node['nrpe']['plugins_dir']
-attribute :skip_check_installation,    :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :install_check,    :kind_of => [ TrueClass, FalseClass ], :default => false

--- a/test/integration/default/bats/lwrp.bats
+++ b/test/integration/default/bats/lwrp.bats
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+@test "lwrp installs check_iowait nrpe" {
+    run test -f /etc/nagios/nrpe.d/check_iowait.cfg
+    [ "$status" -eq 0 ]
+
+    run test -f /usr/lib/nagios/plugins/check_iowait.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "lwrp does not install check_test nrpe" {
+    run test -f /usr/lib/nagios/plugins/check_test
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Install plugin_name source to plugin_dir 

In the nrpe invocation below check_iowait.sh will be installed to /usr/lib/nagios/plugins. 

``` ruby
nrpe "check_iowait" do
  plugin_dir "/usr/lib/nagios/plugins"
  plugin_name "check_iowait.sh"
  plugin_args "10 20"
  install_check true
end
```

If the file is already present on the server, the install_check parameter can be omitted to skip the the installation of the file: 

``` ruby
nrpe "check_iowait" do
  plugin_dir "/usr/lib/nagios/plugins"
  plugin_name "check_iowait.sh"
  plugin_args "10 20"
end
```

I added a test-kitchen test here. I couldn't get the rake command to pass even on a newly cloned repository: 

``` bash
$ rake
Running Food Critic Lint..
Running Knife Check..
bundle exec knife cookbook test -o /Users/Jose/src chef-nrpe
Could not locate Gemfile or .bundle/ directory
rake aborted!
Command failed with status (10): [bundle exec knife cookbook test -o /Users/...]
/Users/Jose/src/chef-nrpe/Rakefile:32:in `block in <top (required)>'
Tasks: TOP => default => lint => knife
(See full trace by running task with --trace)
```
