### PR TITLE
make resource chef13 compatible

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -21,7 +21,7 @@ actions :create, :delete
 
 default_action :create
 
-attribute :command_name,  :name_attribute => true, :kind_of => String, :default => nil
+attribute :command_name,  :name_attribute => true, :kind_of => String
 attribute :plugin_name,   :required => true, :kind_of => String, :default => nil
 attribute :plugin_args,   :required => true, :kind_of => String, :default => nil
 attribute :plugin_dir,    :kind_of => String, :default => node['nrpe']['plugins_dir']


### PR DESCRIPTION
Fixing this message:

```
Cannot specify both default and name_property together on property command_name of resource nrpe. 
Only one (name_property) will be obeyed. In Chef 13, this will become an error.
```
